### PR TITLE
Add permission for workflow release

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -9,6 +9,9 @@ on:
       - idea/*
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: windows-latest


### PR DESCRIPTION
Looks the release workflow failed and likely because your repo isn't setup to allow workflow write permission, this will bypass that for the publish release action.