### PR TITLE
removed double quotes from individual paths

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -55,7 +55,7 @@ public class Add2Path : IPlugin
         {
             int c = path[i];
 
-            if (c == '<' || c == '>' || c == '|' || c == '*' || c == '?' || c < 32)
+            if (c == '<' || c == '>' || c == '|' || c == '*' || c == '?' || c < 32 || c == '/')
                 return false;
         }
 

--- a/Main.cs
+++ b/Main.cs
@@ -210,6 +210,9 @@ public class Add2Path : IPlugin
                         Context.API.ShowMsgError("Failed to add to PATH", $"Failed to add {$"\"{folderPath}\""} to {(system ? "system" : "user")} PATH - {ex.Message}");
                         return true;
                     }
+                    if (folderPath.Contains(';')) {
+                        Context.API.ShowMsgError("Warning to Powershell users", "This path won't work in Powershell because it contains a semicolon. For more information, visit https://github.com/HorridModz/Flow.Launcher.Plugin.Add2Path/pull/8");
+                    } 
                     Context.API.ShowMsg("Successfully added to PATH", $"Successfully added {$"\"{folderPath}\""} to {(system ? "system" : "user")} PATH.");
                     return true;
                 },

--- a/PathUtils.cs
+++ b/PathUtils.cs
@@ -92,9 +92,7 @@ internal static class PathUtils // Renamed from Path to PathUtils, to avoid nami
         // From https://stackoverflow.com/questions/5510343/escape-command-line-arguments-in-c-sharp
         if (string.IsNullOrEmpty(original))
             return original;
-        string value = Regex.Replace(original, @"(\\*)" + "\"", @"$1\$0");
-        value = Regex.Replace(value, @"^(.*\s.*?)(\\*)$", "\"$1$2$2\"");
-        return value;
+        return Regex.Replace(original, @"^(.*\s.*?)(\\*)$", "\"$1$2$2\"");;
     }
 
     private static string _GetRegistryKey(bool system = false)
@@ -148,9 +146,7 @@ internal static class PathUtils // Renamed from Path to PathUtils, to avoid nami
     
     public static void Set(List<string> folderPaths, bool system = false)
     {
-        // Wrap folder paths in quotes
-        folderPaths = (from folderPath in folderPaths select $"\"{folderPath}\"").ToList();
-        PathUtils.SetFullString(String.Join(";", folderPaths), system);
+        PathUtils.SetFullString(String.Join(";", folderPaths.ToList()), system);
     }
 
     public static bool Contains(string folderPath, bool system = false)


### PR DESCRIPTION
https://github.com/HorridModz/Flow.Launcher.Plugin.Add2Path/pull/8/files#diff-8bed8c2318d615e4fc8ba5b31743510f2ec246c511b9b69be5e12d166b8d47f5L58-R58
Just one more illegal path character

https://github.com/HorridModz/Flow.Launcher.Plugin.Add2Path/pull/8/files#diff-04a3de886d5ecc81aed6e5d35743532761ea2674069a0c99eb0348108a44e54cL95-R95
No need to escape double quotes, path cannot contain any in the end

https://github.com/HorridModz/Flow.Launcher.Plugin.Add2Path/pull/8/files#diff-04a3de886d5ecc81aed6e5d35743532761ea2674069a0c99eb0348108a44e54cL151-R149
We shouldn't wrap paths with double quotes (it works on cmd, but powershell cannot read the path when there is double quotes around the paths idk why)

Please let me know if any changes are needed